### PR TITLE
Fix highlighting

### DIFF
--- a/vscode-henna/themes/henna-color-theme.json
+++ b/vscode-henna/themes/henna-color-theme.json
@@ -18,7 +18,7 @@
     "editor.selectionBackground": "#10151a",
     "editorCursor.foreground": "#1abc9c",
     "editor.findMatchBackground": "#1abc9c",
-    "editor.findMatchHighlightBackground": "#e74c3c",
+    "editor.findMatchHighlightBackground": "#161416",
     "editorGroup.background": "#181A1F",
     "editorGroup.border": "#181A1F",
     "editorGroupHeader.tabsBackground": "#181A1F",
@@ -31,7 +31,7 @@
     "editorSuggestWidget.border": "#181A1F",
     "editorSuggestWidget.selectedBackground": "#2c313a",
     "editorWidget.background": "#21272e",
-    "editor.wordHighlightBackground": "#e74c3c",
+    "editor.wordHighlightBackground": "#161416",
     
     "input.background": "#161416",
     "input.border": "#10151a",


### PR DESCRIPTION
Stops the background highlight from making the text hidden when highlighted.

Before:
![image](https://user-images.githubusercontent.com/13520392/40571216-6d0775c6-6041-11e8-95db-0206ac2f29b9.png)

After:
![image](https://user-images.githubusercontent.com/13520392/40571193-21725b4e-6041-11e8-971e-b5d77c2afc91.png)